### PR TITLE
Re-inforce rules on all tabs after timeout (prevent block circumvention)

### DIFF
--- a/src/components/Background/index.jsx
+++ b/src/components/Background/index.jsx
@@ -546,13 +546,8 @@ export class Background extends Component {
               tabId,
               timeout,
             });
-            getTab(tabId).then((tab) => {
-              // get latest tab infos (url)
-              this.redirectTab(
-                tab.id,
-                `${indexUrl}#blocked?url=${encodeURIComponent(tab.url)}`
-              );
-            });
+
+            this.checkAllTabs();
           }
         }, timeout);
       }


### PR DESCRIPTION
Hi @AXeL-dev, another tiny change that prevents circumventing blocking.

Previously, you could just open another tab to have unlimited time.
After timeout when it re-blocks the original tab of a blocked URL it would not block the new tabs.
With single page applications like YouTube this would lead to never blocking again.

This small change uses existing code and logic of the tmpAllowed list to re-inforce rules after timeout.

Have a nice day!

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/AXeL-dev/contributing)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission? (not required)

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable? (no core changes)
- [x] Have you successfully ran tests with your changes locally?
