### PR TITLE
Disable/Enable "Unblock for x minute(s)" Option

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -320,6 +320,9 @@
   "autoReblockOnTimeout": {
     "message": "Auto re-block unblocked websites when time is over"
   },
+  "allowUnblockForWhile": {
+    "message": "Allow unblocking for x minute(s)"
+  },
   "timeOverFor": {
     "message": "Time over for $url$",
     "placeholders": {

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -320,6 +320,9 @@
   "autoReblockOnTimeout": {
     "message": "Rebloquer automatiquement les sites web débloqués une fois le temps écoulé"
   },
+  "allowUnblockForWhile": {
+    "message": "Autoriser le déblocage pour x minute(s)"
+  },
   "timeOverFor": {
     "message": "Temps écoulé pour $url$",
     "placeholders": {

--- a/public/_locales/nl/messages.json
+++ b/public/_locales/nl/messages.json
@@ -320,6 +320,9 @@
   "autoReblockOnTimeout": {
     "message": "Niet-geblokkeerde websites automatisch blokkeren zodra de tijd is verstreken"
   },
+  "allowUnblockForWhile": {
+    "message": "Deblokkeren gedurende x minuut(en) toestaan"
+  },
   "timeOverFor": {
     "message": "Het tijdschema van $url$ is verstreken",
     "placeholders": {

--- a/src/components/Blocked/index.jsx
+++ b/src/components/Blocked/index.jsx
@@ -52,13 +52,16 @@ export class Blocked extends Component {
     };
   }
 
-  getUnblockOptions = (time) => {
-    return [
+  getUnblockOptions = (time, allowUnblockForWhile = true) => {
+    const options = [
       {
         label: translate('unblockOnce'),
         value: UnblockOptions.unblockOnce,
       },
-      {
+    ];
+    
+    if (allowUnblockForWhile) {
+      options.push({
         label: (
           <Pane display="flex" alignItems="center" gap={10}>
             <span>{translate('unblockFor')}</span>
@@ -78,8 +81,10 @@ export class Blocked extends Component {
           </Pane>
         ),
         value: UnblockOptions.unblockForWhile,
-      },
-    ];
+      });
+    }
+    
+    return options;
   };
 
   componentDidMount() {
@@ -101,6 +106,7 @@ export class Blocked extends Component {
         unblock: {
           isEnabled: isDevEnv || defaultUnblockSettings.isEnabled,
           requirePassword: defaultUnblockSettings.requirePassword,
+          allowUnblockForWhile: defaultUnblockSettings.allowUnblockForWhile,
         },
         password: {
           isEnabled: false,
@@ -115,6 +121,10 @@ export class Blocked extends Component {
             hasUnblockButton: items.unblock.isEnabled,
             unblockDialog: {
               ...this.state.unblockDialog,
+              options: this.getUnblockOptions(
+                this.state.unblockDialog.time,
+                items.unblock.allowUnblockForWhile
+              ),
               requirePassword:
                 items.unblock.isEnabled &&
                 items.unblock.requirePassword &&

--- a/src/components/Settings/index.jsx
+++ b/src/components/Settings/index.jsx
@@ -616,6 +616,15 @@ export class Settings extends Component {
         disabled={!this.state.options.unblock.isEnabled}
         margin={0}
       />
+      <Checkbox
+        label={translate('allowUnblockForWhile')}
+        checked={this.state.options.unblock.allowUnblockForWhile}
+        onChange={(event) =>
+          this.setOptions('unblock.allowUnblockForWhile', event.target.checked)
+        }
+        disabled={!this.state.options.unblock.isEnabled}
+        margin={0}
+      />
     </Fragment>
   );
 

--- a/src/helpers/block.js
+++ b/src/helpers/block.js
@@ -78,6 +78,7 @@ export const defaultUnblockSettings = {
   unblockOnceTimeout: 10, // seconds
   displayNotificationOnTimeout: true,
   autoReblockOnTimeout: false,
+  allowUnblockForWhile: true,
 };
 
 export const defaultPasswordSettings = {


### PR DESCRIPTION
Added a new setting to control whether users can temporarily unblock sites for a specified duration. This prevents abuse of the feature (e.g., always using 999 minutes to bypass blocks).

### Changes
- New toggle in Settings → Unblocking: "Allow unblocking for x minute(s)"
- When disabled, only "Unblock once" option appears on blocked pages
- Setting persists in extension storage
- Multi-language support added

### Why
Blocks become ineffective when users can unblock indefinitely. This gives users control over available unblock options.